### PR TITLE
Fix skip deleted records

### DIFF
--- a/dbf-reader/src/main/java/org/jamel/dbf/DbfReader.java
+++ b/dbf-reader/src/main/java/org/jamel/dbf/DbfReader.java
@@ -66,7 +66,7 @@ public class DbfReader implements Closeable {
                 if (nextByte == DATA_ENDED) {
                     return null;
                 } else if (nextByte == DATA_DELETED) {
-                    dataInputStream.skip(header.getRecordLength() - 1);
+                    dataInputStream.skipBytes(header.getRecordLength() - 1);
                 }
             } while (nextByte == DATA_DELETED);
 


### PR DESCRIPTION
BufferedInputStream skips bytes only in the loaded buffer.
In general, M = skip(N); M <= N
