### PR TITLE
Correct field name parsing

### DIFF
--- a/dbf-reader/src/main/java/org/jamel/dbf/structure/DbfField.java
+++ b/dbf-reader/src/main/java/org/jamel/dbf/structure/DbfField.java
@@ -58,8 +58,8 @@ public class DbfField {
             in.readFully(nameBuf, 1, 10);
             nameBuf[0] = firstByte;
 
-            int nonZeroIndex = nameBuf.length - 1;
-            while (nonZeroIndex >= 0 && nameBuf[nonZeroIndex] == 0) nonZeroIndex--;
+            int nonZeroIndex = 0;
+            while (nonZeroIndex < nameBuf.length && nameBuf[nonZeroIndex + 1 ] != 0) nonZeroIndex++;
             field.fieldName = new String(nameBuf, 0, nonZeroIndex + 1);
             byte fieldType  = in.readByte();
             field.dataType = DbfDataType.valueOf(fieldType);    /* 11    */


### PR DESCRIPTION
Fieldname can contain garbage characters in the trailing NULL-bytes. So this loop should go forward.
