### PR TITLE
provide method to operate DataInput instance

### DIFF
--- a/dbf-reader/src/main/java/org/jamel/dbf/DbfReader.java
+++ b/dbf-reader/src/main/java/org/jamel/dbf/DbfReader.java
@@ -83,8 +83,37 @@ public class DbfReader implements Closeable {
     }
 
     /**
-     * Reads and returns the next row in the Dbf stream
+     * for custom user, only when you understand the file content
+     * @param length
+     */
+    public void skipBytes(int length) {
+        try {
+            dataInput.skipBytes(length);
+        } catch (IOException e) {
+            throw new DbfException("Cannot skip " + length + " bytes", e);
+        }
+    }
+
+    /**
      *
+     * for custom user, only when you understand the file content
+     * @param length
+     * @return
+     */
+    public byte[] readBytes(int length) {
+        byte[] bytes = new byte[length];
+        try {
+            dataInput.readFully(bytes);
+            return bytes;
+        } catch (IOException e) {
+            throw new DbfException("Cannot read " + length + " bytes", e);
+        }
+    }
+
+    /**
+     * Reads and returns the next row in the Dbf stream<br/>
+     * a deleted row start with "*" <br/>
+     * a normal row start with " "
      * @return The next row as an Object array.
      */
     public Object[] nextRecord() {
@@ -99,6 +128,31 @@ public class DbfReader implements Closeable {
                 }
             } while (nextByte == DATA_DELETED);
 
+            Object recordObjects[] = new Object[header.getFieldsCount()];
+            for (int i = 0; i < header.getFieldsCount(); i++) {
+                recordObjects[i] = readFieldValue(header.getField(i));
+            }
+            return recordObjects;
+        } catch (EOFException e) {
+            return null; // we currently end reading file
+        } catch (IOException e) {
+            throw new DbfException("Cannot read next record form Dbf file", e);
+        }
+    }
+
+    /**
+     * Reads and returns the next row in the Dbf stream<br/>
+     * a deleted row start with "*" <br/>
+     * a normal row start with " " <br/>
+     * so we just ignore the first byte
+     * @return The next row as an Object array.
+     */
+    public Object[] nextRecordIgnoreDelete() {
+        try {
+            int nextByte = dataInput.readByte();
+            if (nextByte == DATA_ENDED) {
+                return null;
+            }
             Object recordObjects[] = new Object[header.getFieldsCount()];
             for (int i = 0; i < header.getFieldsCount(); i++) {
                 recordObjects[i] = readFieldValue(header.getField(i));
@@ -154,7 +208,7 @@ public class DbfReader implements Closeable {
     protected Number readNumericValue(DbfField field, byte[] buf) throws IOException {
         try {
             byte[] numericBuf = DbfUtils.trimLeftSpaces(buf);
-            boolean processable = numericBuf.length > 0 && !DbfUtils.contains(numericBuf, (byte) '?');
+            boolean processable = numericBuf.length > 0 && !DbfUtils.contains(numericBuf, (byte) '?') && !DbfUtils.contains(numericBuf, (byte) '-');
             return processable ? Double.valueOf(new String(numericBuf)) : null;
         } catch (NumberFormatException e) {
             throw new DbfException("Failed to parse Number from " + field.getName(), e);


### PR DESCRIPTION
halo~
I recently done a job for analysis `show2003.dbf` & `sjshq.dbf `use this library.
In `show2003`, the first row with time info is marked as deleted, so I can't get the record by `nextReord()`.
Even in the first row, some fields' length isn't the same with the define in the header.

So I need read the time info custom by :
```
    /**
     * for custom user, only when you understand the file content<br/>
     * call dataInput.skip(int n)
     * @param length
     */
    skipBytes(int length)
    /**
     * for custom user, only when you understand the file content<br/>
     * call dataInput.readFully(byte[] b)
     * @param length
     */
    readBytes(int length)
```

And then, I also need the other "deleted data" in `show2003`,
So I also add a method:
```
    /**
     * Reads and returns the next row in the Dbf stream<br/>
     * a deleted row start with "*" <br/>
     * a normal row start with " " <br/>
     * so we just ignore the first byte
     * @return The next row as an Object array.
     */
    nextRecordIgnoreDelete()
```

I hope this can help to others!