### PR TITLE
Added enum type of MEMO('M') to fix issue in reading header of files.

### DIFF
--- a/dbf-reader/src/main/java/org/jamel/dbf/structure/DbfDataType.java
+++ b/dbf-reader/src/main/java/org/jamel/dbf/structure/DbfDataType.java
@@ -9,11 +9,12 @@ public enum DbfDataType {
     DATE('D'),
     FLOAT('F'),
     LOGICAL('L'),
+    MEMO('M'),
     NUMERIC('N');
 
     public final byte byteValue;
 
-    private DbfDataType(char byteValue) {
+    DbfDataType(char byteValue) {
         this.byteValue = (byte) (byteValue & 0xff);
     }
 


### PR DESCRIPTION
The current reading of headers would blow up if it had a column type of M(emo).  I added that to the Enum file and it can get past it.  The changes probably will not fully process objects of Memo type but it will at least allow you to get past the header information.