### PR TITLE
Added enum type of MEMO('M') to fix issue in reading header of files.…

### DIFF
--- a/dbf-reader/src/main/java/org/jamel/dbf/structure/DbfDataType.java
+++ b/dbf-reader/src/main/java/org/jamel/dbf/structure/DbfDataType.java
@@ -9,6 +9,7 @@ public enum DbfDataType {
     DATE('D'),
     FLOAT('F'),
     LOGICAL('L'),
+    MEMO('M'),
     NUMERIC('N');
 
     public final byte byteValue;


### PR DESCRIPTION
… done by @russf with the requested revert of the package private constructor

Currently we are using a local patched version to read some DBF files, and I'd love to get this pushed into upstream so I can remove the local jar reference in our build script.